### PR TITLE
Return datetime objects from date utilities

### DIFF
--- a/法律法规追踪报告系统-gemini/src/utils/helpers.py
+++ b/法律法规追踪报告系统-gemini/src/utils/helpers.py
@@ -10,7 +10,7 @@ import os
 import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, Tuple
-from datetime import datetime, timedelta
+from datetime import datetime
 import pandas as pd
 import pendulum
 from urllib.parse import urlparse, urljoin, quote, unquote
@@ -122,19 +122,19 @@ class DateUtils:
     
     @staticmethod
     def parse_chinese_date(date_str: str) -> Optional[datetime]:
-        """解析中文日期格式"""
+        """解析中文日期格式并返回 ``datetime`` 对象"""
         if not date_str:
             return None
-        
+
         try:
             # 标准化日期格式
             date_str = re.sub(r'[年月日]', '-', date_str)
             date_str = re.sub(r'-$', '', date_str)  # 移除末尾的-
             date_str = re.sub(r'--+', '-', date_str)  # 合并多个-
-            
-            # 尝试解析
-            return pendulum.parse(date_str, strict=False).to_date_string()
-        except:
+
+            # 尝试解析为 datetime
+            return pendulum.parse(date_str, strict=False).naive()
+        except Exception:
             return None
     
     @staticmethod
@@ -150,11 +150,11 @@ class DateUtils:
     
     @staticmethod
     def get_date_range(days: int = 7) -> Tuple[datetime, datetime]:
-        """获取指定天数的日期范围"""
+        """获取指定天数的日期范围，返回 ``datetime`` 对象"""
         end_date = pendulum.now()
         start_date = end_date.subtract(days=days)
-        
-        return start_date.to_date_string(), end_date.to_date_string()
+
+        return start_date.naive(), end_date.naive()
     
     @staticmethod
     def is_recent(date: datetime, days: int = 30) -> bool:


### PR DESCRIPTION
## Summary
- Update `parse_chinese_date` to produce naive `datetime` via `pendulum.parse(...).naive()`
- Adjust `get_date_range` to yield start and end `datetime` objects
- Refresh docstrings and imports for new return types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7dd48f4108325a3826cdc33e34185