### PR TITLE
feat: centralize regex patterns and log levels

### DIFF
--- a/法律法规追踪报告系统-gemini/src/config/constants.py
+++ b/法律法规追踪报告系统-gemini/src/config/constants.py
@@ -3,7 +3,7 @@
 定义系统中使用的所有常量
 """
 
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Dict, List
 
 
@@ -200,15 +200,19 @@ SUPPORTED_FILE_TYPES = {
 
 
 # ================== 日志等级映射 ==================
-LOG_LEVELS = {
-    "TRACE": 5,
-    "DEBUG": 10,
-    "INFO": 20,
-    "SUCCESS": 25,
-    "WARNING": 30,
-    "ERROR": 40,
-    "CRITICAL": 50
-}
+class LogLevel(IntEnum):
+    """Loguru supported log levels"""
+
+    TRACE = 5
+    DEBUG = 10
+    INFO = 20
+    SUCCESS = 25
+    WARNING = 30
+    ERROR = 40
+    CRITICAL = 50
+
+
+LOG_LEVELS: Dict[str, int] = {level.name: level.value for level in LogLevel}
 
 
 # ================== 邮件模板 ==================
@@ -248,13 +252,13 @@ API_LIMITS = {
 
 
 # ================== 正则表达式模式 ==================
-REGEX_PATTERNS = {
-    "date": r'\d{4}[-/年]\d{1,2}[-/月]\d{1,2}[日]?',
-    "regulation_number": r'[A-Za-z0-9]{1,10}〔\d{4}〕第?\d{1,4}号?',
-    "phone": r'1[3-9]\d{9}',
-    "email": r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}',
-    "url": r'https?://[^\s<>"{}|\\^`\[\]]+',
-    "chinese_text": r'[\u4e00-\u9fff]+'
+REGEX_PATTERNS: Dict[str, str] = {
+    "chinese_text": r"[\u4e00-\u9fff]+",
+    "date": r"\d{4}[-/年]\d{1,2}[-/月]\d{1,2}[日]?",
+    "regulation_number": r"[A-Za-z0-9]{1,10}〔\d{4}〕第?\d{1,4}号?",
+    "phone": r"1[3-9]\d{9}",
+    "email": r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+    "url": r"https?://[^\s<>\"{}|\\^`\[\]]+",
 }
 
 

--- a/法律法规追踪报告系统-gemini/src/utils/logger.py
+++ b/法律法规追踪报告系统-gemini/src/utils/logger.py
@@ -28,30 +28,33 @@ class LoggerManager:
         """设置日志配置"""
         if self._configured:
             return
-            
+
         # 移除默认处理器
         logger.remove()
-        
+
         # 确保日志目录存在
         log_dir = Path(self.settings.logging.file_path).parent
         log_dir.mkdir(parents=True, exist_ok=True)
-        
+
+        level_name = str(self.settings.logging.level).upper()
+        log_level = LOG_LEVELS.get(level_name, LOG_LEVELS["INFO"])
+
         # 配置控制台输出
         if self.settings.logging.console_output:
             logger.add(
                 sys.stderr,
-                level=self.settings.logging.level,
+                level=log_level,
                 format=self._get_console_format(),
                 colorize=True,
                 backtrace=True,
                 diagnose=True,
                 enqueue=True
             )
-        
+
         # 配置文件输出
         logger.add(
             self.settings.logging.file_path,
-            level=self.settings.logging.level,
+            level=log_level,
             format=self._get_file_format(),
             rotation=self.settings.logging.max_file_size,
             retention=self.settings.logging.backup_count,
@@ -88,7 +91,7 @@ class LoggerManager:
         )
         
         self._configured = True
-        logger.info(f"日志系统初始化完成 - 级别: {self.settings.logging.level}")
+        logger.info(f"日志系统初始化完成 - 级别: {level_name}")
     
     def _get_console_format(self) -> str:
         """获取控制台日志格式"""


### PR DESCRIPTION
## Summary
- define `LogLevel` enum and export `LOG_LEVELS` mapping
- consolidate regex patterns for common text extraction
- use shared log level mapping when configuring logger

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7dd43d20c8325b6d8bb3c783ac7d2